### PR TITLE
added prefs synchronize to be sure that prefs get stored

### DIFF
--- a/inspector/ios-inspector/ForgeModule/prefs_API.m
+++ b/inspector/ios-inspector/ForgeModule/prefs_API.m
@@ -22,7 +22,7 @@
 	NSUserDefaults *prefs = [NSUserDefaults standardUserDefaults];
 	
 	[prefs setObject:value forKey:[@"forge_" stringByAppendingString:key]];
-	
+	[prefs synchronize];
 	[task success:nil];
 }
 
@@ -56,7 +56,7 @@
 	NSUserDefaults *prefs = [NSUserDefaults standardUserDefaults];
 	
 	[prefs removeObjectForKey:[@"forge_" stringByAppendingString:key]];
-	
+    [prefs synchronize];
 	[task success:nil];
 }
 
@@ -68,7 +68,7 @@
 			[prefs removeObjectForKey:key];
 		}
 	} 
-	
+    [prefs synchronize];
 	[task success:nil];
 }
 


### PR DESCRIPTION
this could configured by a config boolean flag

Although the user preferences are stored at intervals it can happen (especially during testing/debugging) that a write gets lost - resulting in interesting problems. 

In addition this the method should be called when the app is backgrounded since in iOS7.0+ user preferences are not automatically synchronise on backgrounding (not implemented in this pull request)

See iOS user preferences synchronise: 
"Writes any modifications to the persistent domains to disk and updates all unmodified persistent domains to what is on disk."
https://developer.apple.com/library/ios/documentation/cocoa/reference/foundation/Classes/NSUserDefaults_Class/Reference/Reference.html
